### PR TITLE
Elevation ruler Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Lancer Speed Provider
+# Lancer Ruler Integration
 
-A [Drag Ruler](https://foundryvtt.com/packages/drag-ruler) speed provider for lancer.  It features integration with conditions and actor types.
+Integration of LANCER's rules for [Drag Ruler](https://foundryvtt.com/packages/drag-ruler) or,
+experimentally, [Elevation Ruler](https://foundryvtt.com/packages/elevationruler). It features
+integration with conditions and actor types to ensure that the range increments shown are correct.
 
 ## Features
 
@@ -15,7 +17,7 @@ A [Drag Ruler](https://foundryvtt.com/packages/drag-ruler) speed provider for la
 
 ### Recommended
 
-Search for “Lancer Speed Provider” on the foundry module browser.
+Search for “Lancer Ruler Integration” or “Lancer Speed Provider” on the foundry module browser.
 
 ### Manual
 

--- a/lancer-provider.js
+++ b/lancer-provider.js
@@ -67,15 +67,28 @@ Hooks.once("dragRuler.ready", (SpeedProvider) => {
 
 Hooks.once("init", () => {
   if (!game.modules.get("elevationruler")?.active) return;
+  if (game.modules.get("drag-ruler")?.active) {
+    Hooks.once("ready", () => {
+      Dialog.prompt({
+        title: "WARNING",
+        content:
+          "WARNING: Drag Ruler and Elevation Ruler both detected as active. These modules conflict. Please disable one.",
+      })
+        .catch(() => {})
+        .then(() => new ModuleManagement().render(true));
+    });
+  }
+
+  const isV12 = game.release.generation >= 12;
+  if (!isV12) Hooks.on("renderSettingsConfig", renderSettingsConfig);
 
   game.settings.register("lancer-speed-provider", "color-standard", {
     name: "lancer-speed-provider.settings.color-standard.label",
     scope: "client",
-    type: new foundry.data.fields.ColorField({
-      required: true,
-      blank: false,
-      initial: "#1e88e5",
-    }),
+    type: isV12
+      ? new foundry.data.fields.ColorField({ required: true, blank: false })
+      : String,
+    default: "#1e88e5",
     config: true,
     onChange: (val) =>
       (CONFIG.elevationruler.SPEED.CATEGORIES.find(
@@ -85,11 +98,10 @@ Hooks.once("init", () => {
   game.settings.register("lancer-speed-provider", "color-boost", {
     name: "lancer-speed-provider.settings.color-boost.label",
     scope: "client",
-    type: new foundry.data.fields.ColorField({
-      required: true,
-      blank: false,
-      initial: "#ffc107",
-    }),
+    type: isV12
+      ? new foundry.data.fields.ColorField({ required: true, blank: false })
+      : String,
+    default: "#ffc107",
     config: true,
     onChange: (val) =>
       (CONFIG.elevationruler.SPEED.CATEGORIES.find(
@@ -99,11 +111,10 @@ Hooks.once("init", () => {
   game.settings.register("lancer-speed-provider", "color-over-boost", {
     name: "lancer-speed-provider.settings.color-over-boost.label",
     scope: "client",
-    type: new foundry.data.fields.ColorField({
-      required: true,
-      blank: false,
-      initial: "#d81b60",
-    }),
+    type: isV12
+      ? new foundry.data.fields.ColorField({ required: true, blank: false })
+      : String,
+    default: "#d81b60",
     config: true,
     onChange: (val) =>
       (CONFIG.elevationruler.SPEED.CATEGORIES.find(
@@ -155,15 +166,15 @@ Hooks.on("updateCombat", (combat, change) => {
 });
 
 function tokenSpeed(token) {
-  if (isStunned(token)) return 0;
   const actor = token.actor;
-  let speed = actor.system.speed + enkidu_all_fours(actor);
-  if (token.actor.statuses.has("prone")) speed /= 2;
+  let speed = actor.system.speed;
+  speed += enkidu_all_fours(actor);
+  if (token.actor.statuses.has("prone")) speed = Math.floor(speed / 2);
   return speed;
 }
 
 function maximumCategoryDistance(token, speedCategory, tokenSpeed) {
-  // if (speedCategory.name === "Unreachable") return Infinity;
+  if (speedCategory.name === "Unreachable") return Infinity;
   if (
     isStunned(token) ||
     (speedCategory.name === "lancer-speed-provider.over-boost" &&
@@ -176,7 +187,7 @@ function maximumCategoryDistance(token, speedCategory, tokenSpeed) {
   )
     return 0;
 
-  tokenSpeed ??= tokenSpeed(token);
+  tokenSpeed ??= CONFIG.elevationruler.SPEED.tokenSpeed(token);
   const startedProne = token.combatant
     ?.getFlag("lancer-speed-provider", "turn-status")
     ?.includes("prone");
@@ -211,4 +222,26 @@ function isStunned(token) {
   return !token.actor.statuses.isDisjointFrom(
     new Set(["stunned", "immobilized", "shutdown", "downandout"]),
   );
+}
+
+function renderSettingsConfig(_app, el) {
+  let standard = game.settings.get("lancer-speed-provider", "color-standard");
+  let boost = game.settings.get("lancer-speed-provider", "color-boost");
+  let ovboost = game.settings.get("lancer-speed-provider", "color-over-boost");
+
+  el.find('[name="lancer-speed-provider.color-standard"]')
+    .parent()
+    .append(
+      `<input type="color" value="${standard}" data-edit="lancer-speed-provider.color-standard">`,
+    );
+  el.find('[name="lancer-speed-provider.color-boost"]')
+    .parent()
+    .append(
+      `<input type="color" value="${boost}" data-edit="lancer-speed-provider.color-boost">`,
+    );
+  el.find('[name="lancer-speed-provider.color-over-boost"]')
+    .parent()
+    .append(
+      `<input type="color" value="${ovboost}" data-edit="lancer-speed-provider.color-over-boost">`,
+    );
 }

--- a/lancer-provider.js
+++ b/lancer-provider.js
@@ -29,23 +29,14 @@ Hooks.once("dragRuler.ready", (SpeedProvider) => {
       const actor = token.actor;
       const effects = Array.from(actor.statuses);
       /**@type{number}*/
-      let speed = actor.system.speed + enkidu_all_fours(actor);
-      const stunned =
-        effects.filter((e) => {
-          return (
-            e.endsWith("stunned") ||
-            e.endsWith("immobilized") ||
-            e.endsWith("shutdown") ||
-            e.endsWith("downandout")
-          );
-        }).length > 0;
+      let speed = tokenSpeed(token);
+      const stunned = isStunned(token);
       // Cant move if stunned or immobilized
       if (stunned) return [{ range: -1, color: "standard" }];
 
       const prone = effects.some((e) => e.endsWith("prone"));
       /** @type {boolean} */
-      const startedProne = game.combat?.combatants
-        .find((c) => c.tokenId === token.id)
+      const startedProne = token.combatant
         ?.getFlag("lancer-speed-provider", "turn-status")
         ?.some((e) => e.endsWith("prone"));
       const slowed = prone || effects.some((e) => e.endsWith("slow"));
@@ -74,6 +65,85 @@ Hooks.once("dragRuler.ready", (SpeedProvider) => {
   dragRuler.registerModule("lancer-speed-provider", LancerSpeedProvider);
 });
 
+Hooks.once("init", () => {
+  if (!game.modules.get("elevationruler")?.active) return;
+
+  game.settings.register("lancer-speed-provider", "color-standard", {
+    name: "lancer-speed-provider.settings.color-standard.label",
+    scope: "client",
+    type: new foundry.data.fields.ColorField({
+      required: true,
+      blank: false,
+      initial: "#1e88e5",
+    }),
+    config: true,
+    onChange: (val) =>
+      (CONFIG.elevationruler.SPEED.CATEGORIES.find(
+        (c) => c.name === "lancer-speed-provider.standard",
+      ).color = Color.from(val)),
+  });
+  game.settings.register("lancer-speed-provider", "color-boost", {
+    name: "lancer-speed-provider.settings.color-boost.label",
+    scope: "client",
+    type: new foundry.data.fields.ColorField({
+      required: true,
+      blank: false,
+      initial: "#ffc107",
+    }),
+    config: true,
+    onChange: (val) =>
+      (CONFIG.elevationruler.SPEED.CATEGORIES.find(
+        (c) => c.name === "lancer-speed-provider.boost",
+      ).color = Color.from(val)),
+  });
+  game.settings.register("lancer-speed-provider", "color-over-boost", {
+    name: "lancer-speed-provider.settings.color-over-boost.label",
+    scope: "client",
+    type: new foundry.data.fields.ColorField({
+      required: true,
+      blank: false,
+      initial: "#d81b60",
+    }),
+    config: true,
+    onChange: (val) =>
+      (CONFIG.elevationruler.SPEED.CATEGORIES.find(
+        (c) => c.name === "lancer-speed-provider.over-boost",
+      ).color = Color.from(val)),
+  });
+
+  CONFIG.elevationruler.SPEED.ATTRIBUTES.WALK = "actor.system.speed";
+  CONFIG.elevationruler.SPEED.CATEGORIES = [
+    {
+      name: "lancer-speed-provider.standard",
+      color: Color.from(
+        game.settings.get("lancer-speed-provider", "color-standard"),
+      ),
+      multiplier: 1,
+    },
+    {
+      name: "lancer-speed-provider.boost",
+      color: Color.from(
+        game.settings.get("lancer-speed-provider", "color-boost"),
+      ),
+      multiplier: 2,
+    },
+    {
+      name: "lancer-speed-provider.over-boost",
+      color: Color.from(
+        game.settings.get("lancer-speed-provider", "color-over-boost"),
+      ),
+      multiplier: 3,
+    },
+    {
+      name: "Unreachable",
+      color: Color.from(0),
+      multiplier: Infinity,
+    },
+  ];
+  CONFIG.elevationruler.SPEED.tokenSpeed = tokenSpeed;
+  CONFIG.elevationruler.SPEED.maximumCategoryDistance = maximumCategoryDistance;
+});
+
 Hooks.on("updateCombat", (combat, change) => {
   if (!("turn" in change) || !combat.current.tokenId) return;
   const token = game.canvas.tokens.get(combat.current.tokenId);
@@ -83,6 +153,38 @@ Hooks.on("updateCombat", (combat, change) => {
   const conditionIds = Array.from(token.actor.statuses);
   combatant.setFlag("lancer-speed-provider", "turn-status", conditionIds);
 });
+
+function tokenSpeed(token) {
+  if (isStunned(token)) return 0;
+  const actor = token.actor;
+  let speed = actor.system.speed + enkidu_all_fours(actor);
+  if (token.actor.statuses.has("prone")) speed /= 2;
+  return speed;
+}
+
+function maximumCategoryDistance(token, speedCategory, tokenSpeed) {
+  // if (speedCategory.name === "Unreachable") return Infinity;
+  if (
+    isStunned(token) ||
+    (speedCategory.name === "lancer-speed-provider.over-boost" &&
+      !canOvercharge(token.actor)) ||
+    ([
+      "lancer-speed-provider.boost",
+      "lancer-speed-provider.over-boost",
+    ].includes(speedCategory.name) &&
+      slowed(token.actor))
+  )
+    return 0;
+
+  tokenSpeed ??= tokenSpeed(token);
+  const startedProne = token.combatant
+    ?.getFlag("lancer-speed-provider", "turn-status")
+    ?.includes("prone");
+  const prone = token.actor.statuses.has("prone");
+  const firstMove = prone || !startedProne;
+  const multiplier = speedCategory.multiplier - (firstMove ? 0 : 1);
+  return tokenSpeed * multiplier;
+}
 
 /**
  * @returns {boolean}
@@ -94,9 +196,19 @@ function canOvercharge(actor) {
   return actor.is_mech();
 }
 
+function slowed(actor) {
+  return !actor.statuses.isDisjointFrom(new Set(["slow", "prone"]));
+}
+
 function enkidu_all_fours(actor) {
   return actor.items.some((i) => i.system.lid === "mf_tokugawa_alt_enkidu") &&
-    Array.from(actor.statuses).some((e) => e.endsWith("dangerzone"))
+    actor.statuses.has("dangerzone")
     ? 3
     : 0;
+}
+
+function isStunned(token) {
+  return !token.actor.statuses.isDisjointFrom(
+    new Set(["stunned", "immobilized", "shutdown", "downandout"]),
+  );
 }

--- a/lancer-provider.js
+++ b/lancer-provider.js
@@ -1,29 +1,3 @@
-// TODO: Remove when it's 100% that ETL is ded.
-Hooks.once("enhancedTerrainLayer.ready", (RuleProvider) => {
-  class LancerRuleProvider extends RuleProvider {
-    /**
-     * TODO: Figure out what ignores difficult terrain
-     * Bulwark Mods (Mech system & npc feature)
-     * Kai Bioplating (Core bonus and npc feature)
-     * Weathering (Npc trait, wallflower, Swallowtail ranger variant)
-     */
-    calculateCombinedCost(terrain, options) {
-      /** @type {Set<string>} */
-      const effects = Array.from(options.token.actor.statuses);
-      const prone = effects.some((e) => e.endsWith("prone"));
-      return Math.max(
-        super.calculateCombinedCost(terrain, options),
-        prone ? 2 : 1,
-      );
-    }
-  }
-
-  enhancedTerrainLayer.registerModule(
-    "lancer-speed-provider",
-    LancerRuleProvider
-  );
-});
-
 Hooks.once("dragRuler.ready", (SpeedProvider) => {
   class LancerSpeedProvider extends SpeedProvider {
     get colors() {
@@ -52,8 +26,6 @@ Hooks.once("dragRuler.ready", (SpeedProvider) => {
 
     /** @param token {Token} The token to check movement */
     getRanges(token) {
-      // const terrain_ruler = !!game.modules.get("terrain-ruler")?.active;
-      const terrain_ruler = false; // It don't werk anymore. Will probably come back in v12
       const actor = token.actor;
       const effects = Array.from(actor.statuses);
       /**@type{number}*/
@@ -78,7 +50,7 @@ Hooks.once("dragRuler.ready", (SpeedProvider) => {
         ?.some((e) => e.endsWith("prone"));
       const slowed = prone || effects.some((e) => e.endsWith("slow"));
       // Handle prone reduced move with terrain layer iff it is installed
-      if (!terrain_ruler && prone) speed = Math.floor(speed / 2);
+      if (prone) speed = Math.floor(speed / 2);
 
       let range = speed;
       const ranges = [];

--- a/lang/en.json
+++ b/lang/en.json
@@ -2,6 +2,11 @@
   "lancer-speed-provider": {
     "standard": "Move",
     "boost": "Boost",
-    "over-boost": "Overcharge + Boost"
+    "over-boost": "Overcharge + Boost",
+    "settings": {
+      "color-standard": { "label": "Standard Move Color" },
+      "color-boost": { "label": "Boost Color" },
+      "color-over-boost": { "label": "Overcharge+Boost Color" }
+    }
   }
 }

--- a/module.json
+++ b/module.json
@@ -1,13 +1,13 @@
 {
   "id": "lancer-speed-provider",
-  "title": "Lancer Speed Provider",
+  "title": "Lancer Ruler Integration",
   "description": "Provides Drag Ruler speed settings for Lancer",
   "authors": [{ "name": "Bolts" }],
   "type": "module",
   "version": "0.0a",
   "compatibility": {
-    "minimum": "11",
-    "verified": "11"
+    "minimum": "12",
+    "verified": "12"
   },
   "relationships": {
     "systems": [
@@ -20,10 +20,16 @@
         }
       }
     ],
-    "requires": [
+    "recommends": [
       {
         "id": "drag-ruler",
-        "type": "module"
+        "type": "module",
+        "reason": "Either Drag Ruler or Elevation Ruler is required. Elevation Ruler is recommended. They conflict, so only enable one"
+      },
+      {
+        "id": "elevationruler",
+        "type": "module",
+        "reason": "Either Drag Ruler or Elevation Ruler is required. Elevation Ruler is recommended. They conflict, so only enable one"
       }
     ]
   },

--- a/module.json
+++ b/module.json
@@ -6,7 +6,7 @@
   "type": "module",
   "version": "0.0a",
   "compatibility": {
-    "minimum": "12",
+    "minimum": "11",
     "verified": "12"
   },
   "relationships": {
@@ -24,12 +24,7 @@
       {
         "id": "drag-ruler",
         "type": "module",
-        "reason": "Either Drag Ruler or Elevation Ruler is required. Elevation Ruler is recommended. They conflict, so only enable one"
-      },
-      {
-        "id": "elevationruler",
-        "type": "module",
-        "reason": "Either Drag Ruler or Elevation Ruler is required. Elevation Ruler is recommended. They conflict, so only enable one"
+        "reason": "Either Drag Ruler or Elevation Ruler is required. Drag Ruler is recommended. They conflict, so only enable one"
       }
     ]
   },


### PR DESCRIPTION
Elevation Ruler support on foundry v11 is experimental and not recommended for hexagonal grids due to bugs in Elevation Ruler.  If both ruler modules are installed, the user will be prompted to disable one.