### PR TITLE
Core Power status and Lycan automation

### DIFF
--- a/lancer-provider.js
+++ b/lancer-provider.js
@@ -155,6 +155,22 @@ Hooks.once("init", () => {
   CONFIG.elevationruler.SPEED.maximumCategoryDistance = maximumCategoryDistance;
 });
 
+Hooks.once("lancer.registerFlows", (steps, flows) => {
+  steps.set("addCorePowerSE", async ({ actor }) => {
+    const ae = getDocumentClass("ActiveEffect");
+    await ae.create({
+      name: game.i18n.localize("lancer-speed-provider.statuses.core_power"),
+      statuses: ["core_power_active"],
+      icon: "systems/lancer/assets/icons/macro-icons/corebonus.svg",
+      "flags.lancer-speed-provider.status": true,
+    }, { parent: actor });
+    return true;
+  });
+  flows
+    .get("CoreActiveFlow")
+    ?.insertStepAfter("consumeCorePower", "addCorePowerSE");
+});
+
 Hooks.on("updateCombat", (combat, change) => {
   if (!("turn" in change) || !combat.current.tokenId) return;
   const token = game.canvas.tokens.get(combat.current.tokenId);

--- a/lancer-provider.js
+++ b/lancer-provider.js
@@ -157,6 +157,7 @@ Hooks.once("init", () => {
 
 Hooks.once("lancer.registerFlows", (steps, flows) => {
   steps.set("addCorePowerSE", async ({ actor }) => {
+    if (actor.statuses.has("core_power_active")) return true;
     const ae = getDocumentClass("ActiveEffect");
     await ae.create(
       {

--- a/lancer-provider.js
+++ b/lancer-provider.js
@@ -158,12 +158,15 @@ Hooks.once("init", () => {
 Hooks.once("lancer.registerFlows", (steps, flows) => {
   steps.set("addCorePowerSE", async ({ actor }) => {
     const ae = getDocumentClass("ActiveEffect");
-    await ae.create({
-      name: game.i18n.localize("lancer-speed-provider.statuses.core_power"),
-      statuses: ["core_power_active"],
-      icon: "systems/lancer/assets/icons/macro-icons/corebonus.svg",
-      "flags.lancer-speed-provider.status": true,
-    }, { parent: actor });
+    await ae.create(
+      {
+        name: game.i18n.localize("lancer-speed-provider.statuses.core_power"),
+        statuses: ["core_power_active"],
+        icon: "systems/lancer/assets/icons/white/corepower.svg",
+        "flags.lancer-speed-provider.status": true,
+      },
+      { parent: actor },
+    );
     return true;
   });
   flows
@@ -181,10 +184,25 @@ Hooks.on("updateCombat", (combat, change) => {
   combatant.setFlag("lancer-speed-provider", "turn-status", conditionIds);
 });
 
+Hooks.on("preDeleteCombatant", (combatant) => {
+  combatant.actor?.effects
+    .filter((e) => e.getFlag("lancer-speed-provider", "status"))
+    .forEach((e) => e.delete());
+});
+
+Hooks.on("preDeleteCombat", (combat) => {
+  combat.combatants.forEach((c) =>
+    c.actor?.effects
+      .filter((e) => e.getFlag("lancer-speed-provider", "status"))
+      .forEach((e) => e.delete()),
+  );
+});
+
 function tokenSpeed(token) {
   const actor = token.actor;
   let speed = actor.system.speed;
   speed += enkidu_all_fours(actor);
+  speed += lycan_go_loud(actor);
   if (token.actor.statuses.has("prone")) speed = Math.floor(speed / 2);
   return speed;
 }
@@ -230,6 +248,13 @@ function slowed(actor) {
 function enkidu_all_fours(actor) {
   return actor.items.some((i) => i.system.lid === "mf_tokugawa_alt_enkidu") &&
     actor.statuses.has("dangerzone")
+    ? 3
+    : 0;
+}
+
+function lycan_go_loud(actor) {
+  return actor.items.some((i) => i.system.lid === "mf_lycan") &&
+    actor.statuses.has("core_power_active")
     ? 3
     : 0;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -7,6 +7,9 @@
       "color-standard": { "label": "Standard Move Color" },
       "color-boost": { "label": "Boost Color" },
       "color-over-boost": { "label": "Overcharge+Boost Color" }
+    },
+    "statuses": {
+      "core_power": "Core Power Active"
     }
   }
 }

--- a/module.json
+++ b/module.json
@@ -7,7 +7,7 @@
   "version": "0.0a",
   "compatibility": {
     "minimum": "11",
-    "verified": "12"
+    "verified": "11"
   },
   "relationships": {
     "systems": [


### PR DESCRIPTION
Add automation to add a core_power_active status effect so when activating core power from the sheet, an indicator is added to the token

Automatically remove the status when leaving combat.

Automatically increase the lycan's speed if it has the core_power_active status.
