### PR TITLE
Shim dnd5e data to work around elevationruler bug

### DIFF
--- a/lancer-provider.js
+++ b/lancer-provider.js
@@ -78,7 +78,29 @@ Hooks.once("init", () => {
   }
 
   const isV12 = game.release.generation >= 12;
-  if (!isV12) Hooks.on("renderSettingsConfig", renderSettingsConfig);
+  if (!isV12) {
+    Hooks.on("renderSettingsConfig", renderSettingsConfig);
+    Hooks.on("canvasInit", (gameCanvas) => {
+      const r = (rule) => {
+        switch (rule) {
+          case "121":
+            return "5105";
+          case "222":
+            return "MANHATTAN";
+          case "euc":
+            return "EUCL";
+          case "111":
+          default:
+            return "555";
+        }
+      };
+      if (gameCanvas.grid.isHex) canvas.grid.diagonalRule = r("111");
+      else
+        canvas.grid.diagonalRule = r(
+          game.settings.get("lancer", "squareGridDiagonals"),
+        );
+    });
+  }
 
   game.settings.register("lancer-speed-provider", "color-standard", {
     name: "lancer-speed-provider.settings.color-standard.label",


### PR DESCRIPTION
Elevation Ruler rolled its own measurement function that does not work
correctly outside of dnd5e. This shims in the data that dnd5e puts into
the grid so that Elevation Ruler actually measures correctly.
Additionally, Elevation Ruler measures wrong for hex grids unless the
diagonal rule is set to equidistant ("555" in dnd parlance, "111" in
lancer.) To work around this, if the grid is hex, always apply the
lancer 111 rule.
